### PR TITLE
Fix rfft for PyTorch >= 1.8

### DIFF
--- a/src/c5.py
+++ b/src/c5.py
@@ -160,9 +160,9 @@ class network(nn.Module):
                                onesided=False)
 
     # uncomment this part if torch 1.8 or higher is used.
-    # N_fft = fft.rfft(N[:, :2, :, :])
-    # F_fft = fft.rfft(F)
-    # N_after_conv = fft.irfft(N_fft * F_fft)
+    # N_fft = fft.rfft2(N[:, :2, :, :])
+    # F_fft = fft.rfft2(F)
+    # N_after_conv = fft.irfft2(N_fft * F_fft)
 
 
 


### PR DESCRIPTION
The _RFFT_ was changed from `torch.rfft(x, 2, ...)` to `torch.fft.rfft2(x)` instead of `torch.fft.rfft` in _PyTorch_ >= 1.8.